### PR TITLE
Add basic support for Native Client

### DIFF
--- a/gtest.js
+++ b/gtest.js
@@ -1,7 +1,9 @@
-var failurecount = 0;
+gtestError = {};
+
+gtestError.failurecount = 0;
 
 // Returns the one-based index of current Failure.
-function currentIndex() {
+gtestError.currentIndex = function() {
   var hash = document.location.hash;
   if (!hash)
     return 0;
@@ -9,54 +11,61 @@ function currentIndex() {
     return parseInt(hash.substr('#failure'.length));
 }
 
-function buttonLabel(index) {
-  if (failurecount == 0)
+gtestError.buttonLabel = function(index) {
+  if (gtestError.failurecount == 0)
     return 'Failure: ?';
   else if (index == 0)
-    return 'Next failure (' + failurecount + ' found)';
+    return 'Next failure (' + gtestError.failurecount + ' found)';
   else
-    return 'Failure ' + index + '/' + failurecount;
+    return 'Failure ' + index + '/' + gtestError.failurecount;
 }
 
-function nextFailure() {
-  var index = currentIndex();
-  if (++index > failurecount || isNaN(index))
+gtestError.nextFailure = function() {
+  var index = gtestError.currentIndex();
+  if (++index > gtestError.failurecount || isNaN(index))
     index = 1;
   document.location.hash = 'failure' + index;
-  document.getElementById('nextFailureButton').value = buttonLabel(index);
+  document.getElementById('nextFailureButton').value =
+      gtestError.buttonLabel(index);
 }
 
-var pres = document.getElementsByTagName('pre');
-var next_failure = 1;
-for (var i = 0; i < pres.length; ++i) {
-  var pre = pres[i];
-  var html = pre.innerHTML;
-  if (html.match(/\[ +FAILED +\]/)) {
-    while (true) {
-      var next = html.replace(/([^>])(\[ +FAILED +\])/,
-                              '$1<a name=failure' + next_failure + '></a>'+
-                              '<span style="background: #faa">$2</span>');
-      if (next.length != html.length) {
-        ++next_failure;
-        html = next;
-        continue;
+gtestError.init = function() {
+  var pres = document.getElementsByTagName('pre');
+  var next_failure = 1;
+  for (var i = 0; i < pres.length; ++i) {
+    var pre = pres[i];
+    var html = pre.innerHTML;
+    if (html.match(/^\[ +FAILED +\]/m)) {
+      while (true) {
+        var next = html.replace(/^(\[ +FAILED +\])/m,
+                                '<a name=failure' + next_failure + '></a>'+
+                                '<span style="background: #faa">$1</span>');
+        if (next.length != html.length) {
+          ++next_failure;
+          html = next;
+          continue;
+        }
+
+        break;
       }
 
-      break;
+      pre.innerHTML = html;
     }
+  }
+  gtestError.failurecount = next_failure - 1;
 
-    pre.innerHTML = html;
+  if (gtestError.failurecount > 0) {
+    // Construct the button and show it.
+    var next = document.createElement('input');
+    next.id = 'nextFailureButton';
+    next.type = 'submit';
+    next.value = gtestError.buttonLabel(gtestError.currentIndex());
+    next.style.position = 'fixed';
+    next.style.right = 0;
+    next.style.top = 0;
+    next.onclick = gtestError.nextFailure;
+    document.body.appendChild(next);
   }
 }
-failurecount = next_failure - 1;
 
-// Construct the button and show it.
-var next = document.createElement('input');
-next.id = 'nextFailureButton';
-next.type = 'submit';
-next.value = buttonLabel(currentIndex());
-next.style.position = 'fixed';
-next.style.right = 0;
-next.style.top = 0;
-next.onclick = nextFailure;
-document.body.appendChild(next);
+gtestError.init();

--- a/manifest.json
+++ b/manifest.json
@@ -5,13 +5,13 @@
   "content_scripts": [
     {
       "matches": [
-        "http://build.chromium.org/p/*/builders/*/compile/logs/stdio"
+        "http://*/*/builders/*/builds/*/steps/*compile/logs/stdio*"
       ],
       "js": ["nexterror.js"]
     },
     {
       "matches": [
-        "http://build.chromium.org/p/*/builders/*tests/logs/stdio*"
+        "http://*/*/builders/*/builds/*/steps/*/logs/stdio*"
       ],
       "js": ["gtest.js"]
     }


### PR DESCRIPTION
Previously, manifest.json made assumptions about host names and buildbot stage
names that prevented the content scripts from being injected in every situation
that they would be useful.  Adding a more permisive matching pattern revealed,
in turn, that the content scripts could not be injected into the same page due
to global namespace conflicts.  gtest.js was put in its own namespace to allow
the scripts to coexist.  gtest.js now adds its button only when errors are
detected.
