### PR TITLE
Update matching scheme from http to https. Update the manifest_version.

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,19 +1,19 @@
 {
   "name": "BuildBot Error",
-  "version": "8",
+  "version": "9",
   "description": "Skip through errors in buildbot output.",
   "content_scripts": [
     {
       "matches": [
-        "http://build.chromium.org/*/builders/*/builds/*/steps/*compile*/logs/stdio*",
-        "http://*.corp.google.com/*/builders/*/builds/*/steps/*compile*/logs/stdio*"
+        "https://build.chromium.org/*/builders/*/builds/*/steps/*compile*/logs/stdio*",
+        "https://*.corp.google.com/*/builders/*/builds/*/steps/*compile*/logs/stdio*"
       ],
       "js": ["nexterror.js"]
     },
     {
       "matches": [
-        "http://build.chromium.org/*/builders/*/builds/*/steps/*/logs/stdio*",
-        "http://*.corp.google.com/*/builders/*/builds/*/steps/*/logs/stdio*"
+        "https://build.chromium.org/*/builders/*/builds/*/steps/*/logs/stdio*",
+        "https://*.corp.google.com/*/builders/*/builds/*/steps/*/logs/stdio*"
       ],
       "js": ["gtest.js"]
     }
@@ -21,5 +21,6 @@
   "icons": {
     "48": "48.png",
     "128": "128.png"
-  }
+  },
+  "manifest_version": 2
 }


### PR DESCRIPTION
Currently, this extension is broken because buildbot has updated from using http to https. This PR updates buildbot-error so that it works on the https-ified buildbot URLs. The only changes are:
- updated the version from 8 to 9
- updated the match scheme from http to https
- specified manifest_version = 2 as per the latest extensions guidelines

I've verified that these changes make the extension work again.
